### PR TITLE
build: add meson option to disable apps

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -65,7 +65,9 @@ subdir('drivers')
 
 # build binaries and installable tools
 subdir('usertools')
-subdir('app')
+if get_option('apps')
+    subdir('app')
+endif
 
 # build docs
 subdir('doc')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,5 +1,7 @@
 # Please keep these options sorted alphabetically.
 
+option('apps', type: 'boolean', value: true, description:
+       'build apps')
 option('check_includes', type: 'boolean', value: false, description:
        'build "chkincs" to verify each header file can compile alone')
 option('cpu_instruction_set', type: 'string', value: 'auto',


### PR DESCRIPTION
I had problems with building DPDK like `multiple definition of ixgbe_flow_list` etc. so I disabled building apps and it fixed the issue.