### PR TITLE
ENA Driver: Remove invalid ring size alignment logic

### DIFF
--- a/drivers/net/ena/ena_ethdev.c
+++ b/drivers/net/ena/ena_ethdev.c
@@ -1255,9 +1255,6 @@ static int ena_tx_queue_setup(struct rte_eth_dev *dev,
 		return -EINVAL;
 	}
 
-	if (nb_desc == RTE_ETH_DEV_FALLBACK_TX_RINGSIZE)
-		nb_desc = adapter->tx_ring_size;
-
 	txq->port_id = dev->data->port_id;
 	txq->next_to_clean = 0;
 	txq->next_to_use = 0;
@@ -1325,9 +1322,6 @@ static int ena_rx_queue_setup(struct rte_eth_dev *dev,
 			queue_idx);
 		return ENA_COM_FAULT;
 	}
-
-	if (nb_desc == RTE_ETH_DEV_FALLBACK_RX_RINGSIZE)
-		nb_desc = adapter->rx_ring_size;
 
 	if (!rte_is_power_of_2(nb_desc)) {
 		RTE_LOG(ERR, PMD,


### PR DESCRIPTION
This a backport of [a fix for the ENA driver](https://github.com/DPDK/dpdk/commit/30a6c7ef4054) that was added in v21.05. Without this fix Seastar/DPDK apps can't run on AWS EC2 instances unless the default ring size is changed.

The previous logic was invalid. The RTE_ETH_DEV_FALLBACK_RX_RINGSIZE (and the TX counterpart) are values
that rte_eth_rx_queue_setup() will set if dev_info.default_rxportconf.ring_size is 0 and user provided 0 in nb_rx_desc argument. However the current code treats it as a hint for the PMD to change the ring size to internal defaults.
